### PR TITLE
Use smaller font size in icon for large tab counts

### DIFF
--- a/src/js/Icon.js
+++ b/src/js/Icon.js
@@ -2,6 +2,8 @@ var size = 19;
 var borderWidth = 2;
 var borderRadius = 3;
 var textPosition = 13;
+var bigFont = 'bold 11px sans-serif';
+var smallFont = 'bold 9px sans-serif';
 
 // http://git.chromium.org/gitweb/?p=chromium/src.git;a=blob;f=chrome/renderer/resources/extensions/set_icon.js;h=f9f2371fe83befca510a118e9c564b343203a2a5;hb=e7cda74cc2dfe47adbf6cbe8c86a0c57b19cad56
 // http://git.chromium.org/gitweb/?p=chromium/src.git;a=blob;f=chrome/test/data/extensions/api_test/browser_action/no_icon/update.js;h=e37a28603ecc6a8fc8a521fcfe7bc5514beda63b;hb=e7cda74cc2dfe47adbf6cbe8c86a0c57b19cad56
@@ -12,7 +14,6 @@ canvas.width = size;
 canvas.height = size;
 
 var ctx = canvas.getContext('2d');
-ctx.font = 'bold 11px sans-serif';
 ctx.strokeStyle = '#5c5c5c';
 ctx.fillStyle = '#5c5c5c';
 ctx.lineWidth = borderWidth;
@@ -26,6 +27,11 @@ ctx.fill();
  * Draws the icon
  */
 export function drawIcon(text) {
+	if (text.length >= 3) {
+		ctx.font = smallFont;
+	} else {
+		ctx.font = bigFont;
+	}
 	ctx.clearRect(borderWidth, borderWidth, innerSize, innerSize);
 	ctx.fillText(text, size / 2, textPosition);
 	return ctx.getImageData(0, 0, size, size)


### PR DESCRIPTION
Hi, 

this commit fixes tab count display for 3-digit tab counts. Since dynamically modifying text size in Canvas is kind of a pain and I haven't heard of any users able to run Chrome with >999 tabs I decided to only add a fixed smaller text size for numbers with more than 2 digits.
Until #3 is fixed this can only guess what a suitable font size is.

Result (before left, after right)
![image](https://cloud.githubusercontent.com/assets/1082036/6254636/9076b276-b7aa-11e4-8603-2323d6546213.png)
