### PR TITLE
Fix 3 digit tab counts

### DIFF
--- a/src/js/Icon.js
+++ b/src/js/Icon.js
@@ -42,6 +42,7 @@ ctx.fill();
  * @param text: text to draw (String or Number)
  */
 export function drawIcon(text) {
+	text = text.toString();
 	// Clear the inner part of the icon, without ever redrawing the border
 	ctx.clearRect(borderWidth, borderWidth, innerSize, innerSize);
 

--- a/src/js/Icon.js
+++ b/src/js/Icon.js
@@ -49,7 +49,7 @@ export function drawIcon(text) {
 	// Draw the text
 	if (text.length >= 3) {
 		ctx.font = smallFont;
-		ctx.fillText(text, iconSize / 2, textPosition);
+		ctx.fillText(text, iconSize / 2, textPosition, innerSize);
 	} else {
 		ctx.font = bigFont;
 		ctx.fillText(text, iconSize / 2, textPosition);


### PR DESCRIPTION
Fix for #10. 

Roboto is a quite wide font (even the condensed version has large letter spacings) and probably not the best choice, but compressing the rendered output to fit inside the symbol looks ok most of the time (Canvas doesn't support changing the letter spacing)

![image](https://cloud.githubusercontent.com/assets/1082036/6315287/ab5da072-b9fd-11e4-9c49-c6f991d4b5f7.png)
